### PR TITLE
Add OAuth2 info to README

### DIFF
--- a/tutorials/oauth/python/README.md
+++ b/tutorials/oauth/python/README.md
@@ -102,6 +102,7 @@ In this example, a service principal is used to get the AAD credential by settin
 export AZURE_TENANT_ID=<TenantID>
 export AZURE_CLIENT_ID=<AppClientId>
 export AZURE_CLIENT_SECRET=<AppSecret>
+```
 
 An RBAC role must be assigned to the application to gain access to Event Hubs. Azure provides built-in roles for authorizing access to Event Hubs. See [Azure Built in Roles for Azure Event Hubs](https://docs.microsoft.com/en-us/azure/event-hubs/authorize-access-azure-active-directory#azure-built-in-roles-for-azure-event-hubs).
 
@@ -112,11 +113,11 @@ To create a service principal and assign RBAC roles to the application, review [
 
 To connect a Kafka client to Event Hub using OAuth 2.0, the following configuration is required:
 
-```
-    bootstrap.servers=<namespace>.servicebus.windows.net:9093
-    security.protocol=SASL_SSL
-    sasl.mechanism=OAUTHBEARER
-    oauth_cb=<Callback for retrieving OAuth Bearer token> 
+```properties
+bootstrap.servers=<namespace>.servicebus.windows.net:9093
+security.protocol=SASL_SSL
+sasl.mechanism=OAUTHBEARER
+oauth_cb=<Callback for retrieving OAuth Bearer token> 
 ```
 
 The return value of `oauth_cb` is expected to be a (token_str, expiry_time) tuple where expiry_time is the time in seconds since the epoch as a floating point number.

--- a/tutorials/oauth/python/README.md
+++ b/tutorials/oauth/python/README.md
@@ -88,7 +88,7 @@ python consumer.py
 
 Event Hubs integrates with Azure Active Directory (Azure AD), which provides an OAuth 2.0 compliant authorization server. Azure role-based access control (Azure RBAC) can be used to grant permissions to Kafka client identities. 
 
-To grant access to an Event Hub resource, first the security principal must be authenicated and an OAuth 2.0 token is returned. The token is then passed as part of the request to the Event Hub Service to authorize access to the resource. This is accomplished by setting the appropriate values in the Kafka client configuration. 
+To grant access to an Event Hub resource, the security principal must be authenticated and an OAuth 2.0 token is returned. The token is then passed as part of the request to the Event Hub Service to authorize access to the resource. This is accomplished by setting the appropriate values in the Kafka client configuration. 
 
 For more information on the Azure AD OAuth 2.0 for Event Hubs see [Authorize access with Azure Active Directory](https://docs.microsoft.com/en-us/azure/event-hubs/authorize-access-azure-active-directory#overview)
 
@@ -96,7 +96,7 @@ For more information on the Azure AD OAuth 2.0 for Event Hubs see [Authorize acc
 
 The `DefaultAzureCredential` Class can be used to get a credential, and Kafka clients must use the scope of `https://<namespace>.servicebus.windows.net` to retrieve the access token from the Event Hub namespace. See [DefaultAzureCredential](https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) for more information on this class. 
 
-A service principal is used in this example to get an AAD credential by setting the following environment variables:    
+In this example, a service principal is used to get the AAD credential by setting the following environment variables:    
 
 ```
 AZURE_CLIENT_ID=<AppClientId>
@@ -122,7 +122,7 @@ To connect a Kafka client to Event Hub using OAuth 2.0, the following configurat
 
 The return value of `oauth_cb` is expected to be a (token_str, expiry_time) tuple where expiry_time is the time in seconds since the epoch as a floating point number.
 
-An example `oauth_cb` is defined by `_get_token` below:
+An example `oauth_cb` is defined by the `_get_token` function below:
 
 ```python
 
@@ -130,7 +130,7 @@ AUTH_SCOPE="https://<namespace>.servicebus.windows.net/.default"
 cred = DefaultAzureCredential()
 
 def _get_token(config):
-    """config comes from sasl.oauthbearer.config below.
+    """confluent_kafka passes 'sasl.oauthbearer.config' as the config param
     """
     access_token = cred.get_token(AUTH_SCOPE)
     return access_token.token, access_token.expires_on

--- a/tutorials/oauth/python/README.md
+++ b/tutorials/oauth/python/README.md
@@ -125,6 +125,9 @@ See [Confluent Kafka for Python](https://docs.confluent.io/platform/current/clie
 An example `oauth_cb` and kafka client configuration is defined below:
 
 ```python
+from azure.identity import DefaultAzureCredential
+from functools import partial
+
 def oauth_cb(cred, namespace_fqdn, config):
     # note: confluent_kafka passes 'sasl.oauthbearer.config' as the config param
     access_token = cred.get_token('https://%s/.default' % namespace_fqdn)
@@ -138,4 +141,7 @@ kafka_conf = {
     'sasl.mechanism': 'OAUTHBEARER',
     'oauth_cb': partial(oauth_cb, az_credential, eh_namespace_fqdn),
 }
+
+# Create Producer instance
+p = Producer(kafka_conf)
 ```

--- a/tutorials/oauth/python/README.md
+++ b/tutorials/oauth/python/README.md
@@ -98,11 +98,10 @@ The `DefaultAzureCredential` Class can be used to get a credential, and Kafka cl
 
 In this example, a service principal is used to get the AAD credential by setting the following environment variables:    
 
-```
-AZURE_CLIENT_ID=<AppClientId>
-AZURE_CLIENT_SECRET=<AppSecret>
-AZURE_TENANT_ID=<TenantID>
-```
+```shell
+export AZURE_TENANT_ID=<TenantID>
+export AZURE_CLIENT_ID=<AppClientId>
+export AZURE_CLIENT_SECRET=<AppSecret>
 
 An RBAC role must be assigned to the application to gain access to Event Hubs. Azure provides built-in roles for authorizing access to Event Hubs. See [Azure Built in Roles for Azure Event Hubs](https://docs.microsoft.com/en-us/azure/event-hubs/authorize-access-azure-active-directory#azure-built-in-roles-for-azure-event-hubs).
 


### PR DESCRIPTION
Adds information on how to connect to Event Hub using OAuth2

Describes or points to existing docs for:
- how to get a token
- Azure built in RBAC roles
- how configure Kafka clients

Please let me know if something isn't clear or if something is missing. 