### PR TITLE
Use upstream sample as the base for Python producer/consumer

### DIFF
--- a/tutorials/oauth/python/consumer.py
+++ b/tutorials/oauth/python/consumer.py
@@ -7,63 +7,115 @@
 #
 # Original Confluent sample modified for use with Azure Event Hubs for Apache Kafka Ecosystems
 
-import signal
-import sys
-import time
-from confluent_kafka import Consumer
 from azure.identity import DefaultAzureCredential
-from dotenv import load_dotenv
-import os
-
-load_dotenv()
-
-FULLY_QUALIFIED_NAMESPACE= os.environ['EVENT_HUB_HOSTNAME']
-EVENTHUB_NAME = os.environ['EVENT_HUB_NAME']
-CONSUMER_GROUP='$Default'
-AUTH_SCOPE= "https://" + FULLY_QUALIFIED_NAMESPACE +"/.default"
-
-# AAD
-cred = DefaultAzureCredential()
+from confluent_kafka import Consumer, KafkaException
+import sys
+import getopt
+import json
+import logging
+from functools import partial
+from pprint import pformat
 
 
-def _get_token(config):
-    """Note here value of config comes from sasl.oauthbearer.config below.
-    It is not used in this example but you can put arbitrary values to
-    configure how you can get the token (e.g. which token URL to use)
-    """
-    access_token = cred.get_token(AUTH_SCOPE)
-    return access_token.token, time.time() + access_token.expires_on
+def stats_cb(stats_json_str):
+    stats_json = json.loads(stats_json_str)
+    print('\nKAFKA Stats: {}\n'.format(pformat(stats_json)))
 
 
-consumer = Consumer({
-    "bootstrap.servers": FULLY_QUALIFIED_NAMESPACE + ":9093",
-    "sasl.mechanism": "OAUTHBEARER",
-    "security.protocol": "SASL_SSL",
-    "oauth_cb": _get_token,
-    "group.id": CONSUMER_GROUP,
-    # "debug": "broker,topic,msg"
-})
+def oauth_cb(cred, namespace_fqdn, config):
+    access_token = cred.get_token('https://%s/.default' % namespace_fqdn)
+    return access_token.token, access_token.expires_on
 
 
-def signal_handler(sig, frame):
-    print("exiting")
-    consumer.close()
-    sys.exit(0)
+def print_usage_and_exit(program_name):
+    sys.stderr.write(
+        'Usage: %s [options..] <eventhubs-namespace> <group> <topic1> <topic2> ..\n' % program_name)
+    options = '''
+ Options:
+  -T <intvl>   Enable client statistics at specified interval (ms)
+'''
+    sys.stderr.write(options)
+    sys.exit(1)
 
 
-signal.signal(signal.SIGINT, signal_handler)
+if __name__ == '__main__':
+    optlist, argv = getopt.getopt(sys.argv[1:], 'T:')
+    if len(argv) < 3:
+        print_usage_and_exit(sys.argv[0])
 
-print("consuming " + EVENTHUB_NAME)
-consumer.subscribe([EVENTHUB_NAME])
+    namespace = argv[0]
+    group = argv[1]
+    topics = argv[2:]
 
-while True:
-    msg = consumer.poll(1.0)
+    # Azure credential
+    cred = DefaultAzureCredential()
 
-    if msg is None:
-        continue
-    if msg.error():
-        print(f"Consumer error: {msg.error()}")
-        continue
+    # Consumer configuration
+    # See https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+    conf = {
+        'bootstrap.servers': '%s:9093' % namespace,
+        'group.id': group,
+        'session.timeout.ms': 6000,
+        'auto.offset.reset': 'earliest',
 
-    print(
-        f"Received message [{msg.partition()}]: {msg.value().decode('utf-8')}")
+        # Required OAuth2 configuration properties
+        'security.protocol': 'SASL_SSL',
+        'sasl.mechanism': 'OAUTHBEARER',
+        'oauth_cb': partial(oauth_cb, cred, namespace),
+    }
+
+    # Check to see if -T option exists
+    for opt in optlist:
+        if opt[0] != '-T':
+            continue
+        try:
+            intval = int(opt[1])
+        except ValueError:
+            sys.stderr.write("Invalid option value for -T: %s\n" % opt[1])
+            sys.exit(1)
+
+        if intval <= 0:
+            sys.stderr.write("-T option value needs to be larger than zero: %s\n" % opt[1])
+            sys.exit(1)
+
+        conf['stats_cb'] = stats_cb
+        conf['statistics.interval.ms'] = int(opt[1])
+
+    # Create logger for consumer (logs will be emitted when poll() is called)
+    logger = logging.getLogger('consumer')
+    logger.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter('%(asctime)-15s %(levelname)-8s %(message)s'))
+    logger.addHandler(handler)
+
+    # Create Consumer instance
+    # Hint: try debug='fetch' to generate some log messages
+    c = Consumer(conf, logger=logger)
+
+    def print_assignment(consumer, partitions):
+        print('Assignment:', partitions)
+
+    # Subscribe to topics
+    c.subscribe(topics, on_assign=print_assignment)
+
+    # Read messages from Kafka, print to stdout
+    try:
+        while True:
+            msg = c.poll(timeout=1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                raise KafkaException(msg.error())
+            else:
+                # Proper message
+                sys.stderr.write('%% %s [%d] at offset %d with key %s:\n' %
+                                 (msg.topic(), msg.partition(), msg.offset(),
+                                  str(msg.key())))
+                print(msg.value())
+
+    except KeyboardInterrupt:
+        sys.stderr.write('%% Aborted by user\n')
+
+    finally:
+        # Close down consumer to commit final offsets.
+        c.close()

--- a/tutorials/oauth/python/producer.py
+++ b/tutorials/oauth/python/producer.py
@@ -7,60 +7,66 @@
 #
 # Original Confluent sample modified for use with Azure Event Hubs for Apache Kafka Ecosystems
 
-import time
-from confluent_kafka import Producer
 from azure.identity import DefaultAzureCredential
-from dotenv import load_dotenv
-import os
-
-load_dotenv()
-
-FULLY_QUALIFIED_NAMESPACE= os.environ['EVENT_HUB_HOSTNAME']
-EVENTHUB_NAME = os.environ['EVENT_HUB_NAME']
-AUTH_SCOPE= "https://" + FULLY_QUALIFIED_NAMESPACE +"/.default"
-
-# AAD
-cred = DefaultAzureCredential()
-
-def _get_token(config):
-    """Note here value of config comes from sasl.oauthbearer.config below.
-    It is not used in this example but you can put arbitrary values to
-    configure how you can get the token (e.g. which token URL to use)
-    """
-    access_token = cred.get_token(AUTH_SCOPE)
-    return access_token.token, time.time() + access_token.expires_on
+from confluent_kafka import Producer
+import sys
+from functools import partial
 
 
-producer = Producer({
-    "bootstrap.servers": FULLY_QUALIFIED_NAMESPACE + ":9093",
-    "sasl.mechanism": "OAUTHBEARER",
-    "security.protocol": "SASL_SSL",
-    "oauth_cb": _get_token,
-    "enable.idempotence": True,
-    "acks": "all",
-    # "debug": "broker,topic,msg"
-})
+def oauth_cb(cred, namespace_fqdn, config):
+    access_token = cred.get_token('https://%s/.default' % namespace_fqdn)
+    return access_token.token, access_token.expires_on
 
 
-def delivery_report(err, msg):
-    """Called once for each message produced to indicate delivery result.
-    Triggered by poll() or flush()."""
-    if err is not None:
-        print(f"Message delivery failed: {err}")
-    else:
-        print(f"Message delivered to {msg.topic()} [{msg.partition()}]")
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        sys.stderr.write('Usage: %s <eventhubs-namespace> <topic>\n' % sys.argv[0])
+        sys.exit(1)
 
+    namespace = sys.argv[1]
+    topic = sys.argv[2]
 
-some_data_source = [str(i) for i in range(1000)]
-for data in some_data_source:
-    # Trigger any available delivery report callbacks from previous produce() calls
-    producer.poll(0)
+    # Azure credential
+    cred = DefaultAzureCredential()
 
-    # Asynchronously produce a message, the delivery report callback
-    # will be triggered from poll() above, or flush() below, when the message has
-    # been successfully delivered or failed permanently.
-    producer.produce(EVENTHUB_NAME, f"Hello {data}".encode("utf-8"), callback=delivery_report)
+    # Producer configuration
+    # See https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+    conf = {
+        'bootstrap.servers': '%s:9093' % namespace,
 
-# Wait for any outstanding messages to be delivered and delivery report
-# callbacks to be triggered.
-producer.flush()
+        # Required OAuth2 configuration properties
+        'security.protocol': 'SASL_SSL',
+        'sasl.mechanism': 'OAUTHBEARER',
+        'oauth_cb': partial(oauth_cb, cred, namespace),
+    }
+
+    # Create Producer instance
+    p = Producer(**conf)
+
+    # Optional per-message delivery callback (triggered by poll() or flush())
+    # when a message has been successfully delivered or permanently
+    # failed delivery (after retries).
+    def delivery_callback(err, msg):
+        if err:
+            sys.stderr.write('%% Message failed delivery: %s\n' % err)
+        else:
+            sys.stderr.write('%% Message delivered to %s [%d] @ %d\n' %
+                             (msg.topic(), msg.partition(), msg.offset()))
+
+    # Write 1-100 to topic
+    for i in range(0, 100):
+        try:
+            p.produce(topic, str(i), callback=delivery_callback)
+        except BufferError:
+            sys.stderr.write('%% Local producer queue is full (%d messages awaiting delivery): try again\n' %
+                             len(p))
+
+        # Serve delivery callback queue.
+        # NOTE: Since produce() is an asynchronous API this poll() call
+        #       will most likely not serve the delivery callback for the
+        #       last produce()d message.
+        p.poll(0)
+
+    # Wait until all messages have been delivered
+    sys.stderr.write('%% Waiting for %d deliveries\n' % len(p))
+    p.flush()


### PR DESCRIPTION
Uses upstream confluent_kafka samples as a base for the OAuth2 sample rather than the one-off pattern. Fixes showstopper bugs

* fixes access token expiry bug
* removes dotenv-python dependency

Use of older Python string formatting within this PR is intentional to match upstream/etc. This is the minimum configuration needed to set up OAuth in a "real application" (no global vars, enclosed in a proper `__main__` function, etc)

References:

* Upstream confluent_kafka:
  * https://github.com/confluentinc/confluent-kafka-python/blob/master/examples/consumer.py
  * https://github.com/confluentinc/confluent-kafka-python/blob/master/examples/producer.py
* Quickstart within this repo:
  * https://github.com/Azure/azure-event-hubs-for-kafka/blob/master/quickstart/python/consumer.py
  * https://github.com/Azure/azure-event-hubs-for-kafka/blob/master/quickstart/python/producer.py

Usage (ignore the current readme):

```shell
# No setup required for Azure CLI or Managed Identity, assuming you have the right role assignments
# Must have Azure Event Hubs Data Receiver + Azure Event Hubs Data Sender on the target Event Hubs namespace

# For Service Principal: define AAD credentials
export AZURE_TENANT_ID=<tenant>
export AZURE_CLIENT_ID=<clientId>
export AZURE_CLIENT_SECRET=<password>

# Install dependencies
python -m pip install confluent-kafka azure-identity

# start a consumer
python consumer.py noelkafka.servicebus.windows.net myconsumer topic1

# produce some messages
python producer.py noelkafka.servicebus.windows.net topic1
```