### PR TITLE
Update python oauth readme

### DIFF
--- a/tutorials/oauth/python/README.md
+++ b/tutorials/oauth/python/README.md
@@ -14,7 +14,7 @@ For more information on using Azure AD with Event Hubs, see [Authorize access wi
 
 ### Retrieve Azure Active Directory (AAD) Token
 
-The `DefaultAzureCredential` class from the [Azure Identity client library](https://docs.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python) can be used to get a credential with the scope of `https://<namespace>.servicebus.windows.net` to retrieve the access token for the Event Hubs namespace.
+The `DefaultAzureCredential` class from the [Azure Identity client library](https://docs.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python) can be used to get a credential with the scope of `https://<namespace>.servicebus.windows.net/.default` to retrieve the access token for the Event Hubs namespace.
 
 This class is suitable for use with Azure CLI for local development, Managed Identity for Azure deployments, and with service principal client secrets/certificates. See [DefaultAzureCredential](https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) for more information on this class.
 
@@ -113,7 +113,7 @@ export AZURE_CLIENT_SECRET=<AppSecret>
 python producer.py mynamespace.servicebus.windows.net topic1
 ```
 
-> Note that the topic must already exist or else you will see an "Unknown topic or partition" error.
+> Note: the topic must already exist, or will see an "Unknown topic or partition" error when running with the `Azure Event Hubs Data Sender` role. With the `Azure Event Hubs Data Owner` role, the topic (Event Hub) will be automatically created.
 
 ### Consuming
 

--- a/tutorials/oauth/python/README.md
+++ b/tutorials/oauth/python/README.md
@@ -1,117 +1,32 @@
-# Using Confluent's Python Kafka client and librdkafka with Event Hubs for Apache Kafka Ecosystems
+# Using Azure Active Directory authentication with Python and Event Hubs for Apache Kafka
 
-This quickstart will show how to create and connect to an Event Hubs Kafka endpoint using an example producer and consumer written in python. Azure Event Hubs for Apache Kafka Ecosystems supports [Apache Kafka version 1.0](https://kafka.apache.org/10/documentation.html) and later.
+This tutorial will show how to create and connect to an Event Hubs Kafka endpoint using Azure Active Directory authentication. Azure Event Hubs for Apache Kafka supports [Apache Kafka version 1.0](https://kafka.apache.org/10/documentation.html) and later.
 
-This sample is based on [Confluent's Apache Kafka Python client](https://github.com/confluentinc/confluent-kafka-python), modified for use with Event Hubs for Kafka.  While the tutorial is aimed at Linux users, MacOS users can follow along with Homebrew.
+This sample is based on [Confluent's Apache Kafka Python client](https://github.com/confluentinc/confluent-kafka-python), modified for use with Event Hubs for Kafka.
 
-## Prerequisites
+## Overview
 
-If you don't have an Azure subscription, create a [free account](https://azure.microsoft.com/free/?ref=microsoft.com&utm_source=microsoft.com&utm_medium=docs&utm_campaign=visualstudio) before you begin.
+Event Hubs integrates with Azure Active Directory (Azure AD), which provides an OAuth 2.0 compliant authorization server. Azure role-based access control (Azure RBAC) can be used to grant permissions to Kafka client identities.
 
-In addition:
+To grant access to an Event Hubs resource, the security principal must be authenticated and an OAuth 2.0 token is returned. The token is then passed as part of the request to the Event Hubs service to authorize access to the resource. This is done by setting the appropriate values in the Kafka client configuration.
 
-* [Git](https://www.git-scm.com/downloads)
-* [Python](https://www.python.org/downloads/) (versions 2.7.x and 3.6.x are fine)
-* [Pip](https://pypi.org/project/pip/)
-* [OpenSSL](https://www.openssl.org/) (including libssl)
-* [librdkafka](https://github.com/edenhill/librdkafka)
-
-Running the setup script provided in this repo will install and configure all of the required dependencies.
-
-## Create an Event Hubs namespace
-
-An Event Hubs namespace is required to send or receive from any Event Hubs service. See [Create Kafka-enabled Event Hubs](https://docs.microsoft.com/azure/event-hubs/event-hubs-create-kafka-enabled) for instructions on getting an Event Hubs Kafka endpoint. Make sure to copy the Event Hubs connection string for later use.
-
-## Getting ready
-
-Now that you have a Kafka-enabled Event Hubs connection string, clone the Azure Event Hubs for Kafka repository and navigate to the `quickstart/python` subfolder:
-
-```bash
-git clone https://github.com/Azure/azure-event-hubs-for-kafka.git
-cd azure-event-hubs-for-kafka/quickstart/python
-```
-
-Now run the set up script:
-
-```shell
-source setup.sh
-```
-
-(If using MacOS, you can use Homebrew to set up your machine by running `brew install openssl python librdkafka` - `pip` can then be used to install the Python SDK with `pip install confluent-kafka`.)
-
-## Running the samples
-
-### Update your configurations
-
-Both the producer and consumer samples require extra configuration to authenticate with your Event Hubs namespace. Add required configurations to environment (.env) file at the root folder.
-
-    AZURE_AUTHORITY_HOST=login.microsoftonline.com
-
-    AZURE_CLIENT_ID=<<AppClientId>>
-
-    AZURE_CLIENT_SECRET=<<AppSecret>>
-
-    AZURE_TENANT_ID=<<TenantID>>
-
-    AZURE_CLIENT_CERTIFICATE_PATH=<<AzureAdClientSecretCertPath>> ## For Certs remove the AZURE_CLIENT_SECRET entry from .env file
-    
-    AZURE_CLIENT_SEND_CERTIFICATE_CHAIN=<<TrueToValidateISsuesAndSubjectName>>
-  
-    EVENT_HUB_HOSTNAME=<<EventHubNameSpace>>
-
-    EVENT_HUB_NAME=<<EvemtHubName>>
-
-    CONSUMER_GROUP=<<ConsumerGroupName>>
-
-### Producing
- 
-```shell 
-python producer.py <topic>
-```
-
-Note that the topic must already exist or else you will see an "Unknown topic or partition" error.
-
-### Consuming
-
-```shell
-python consumer.py 
-```
-
-### Dependencies
-
-    **Azure.Identity** -> For Azure AD AUTH. Please refer defaultazurecredential
-
-    **Confluent-Kafka** -> To connect to EventHub using Kafka protocol
-
-
-## OAuth 2.0 Overview
-
-Event Hubs integrates with Azure Active Directory (Azure AD), which provides an OAuth 2.0 compliant authorization server. Azure role-based access control (Azure RBAC) can be used to grant permissions to Kafka client identities. 
-
-To grant access to an Event Hub resource, the security principal must be authenticated and an OAuth 2.0 token is returned. The token is then passed as part of the request to the Event Hub Service to authorize access to the resource. This is accomplished by setting the appropriate values in the Kafka client configuration. 
-
-For more information on the Azure AD OAuth 2.0 for Event Hubs see [Authorize access with Azure Active Directory](https://docs.microsoft.com/en-us/azure/event-hubs/authorize-access-azure-active-directory#overview)
+For more information on using Azure AD with Event Hubs, see [Authorize access with Azure Active Directory](https://docs.microsoft.com/en-us/azure/event-hubs/authorize-access-azure-active-directory#overview)
 
 ### Retrieve Azure Active Directory (AAD) Token
 
-The `DefaultAzureCredential` Class can be used to get a credential, and Kafka clients must use the scope of `https://<namespace>.servicebus.windows.net` to retrieve the access token from the Event Hub namespace. See [DefaultAzureCredential](https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) for more information on this class. 
+The `DefaultAzureCredential` class from the [Azure Identity client library](https://docs.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python) can be used to get a credential with the scope of `https://<namespace>.servicebus.windows.net` to retrieve the access token for the Event Hubs namespace.
 
-In this example, a service principal is used to get the AAD credential by setting the following environment variables:    
+This class is suitable for use with Azure CLI for local development, Managed Identity for Azure deployments, and with service principal client secrets/certificates. See [DefaultAzureCredential](https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) for more information on this class.
 
-```shell
-export AZURE_TENANT_ID=<TenantID>
-export AZURE_CLIENT_ID=<AppClientId>
-export AZURE_CLIENT_SECRET=<AppSecret>
-```
+### Role Assignments
 
 An RBAC role must be assigned to the application to gain access to Event Hubs. Azure provides built-in roles for authorizing access to Event Hubs. See [Azure Built in Roles for Azure Event Hubs](https://docs.microsoft.com/en-us/azure/event-hubs/authorize-access-azure-active-directory#azure-built-in-roles-for-azure-event-hubs).
 
 To create a service principal and assign RBAC roles to the application, review [How to Create a Service Principal](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal).
 
+### Kafka Client Configuration
 
-### Client Configuration
-
-To connect a Kafka client to Event Hub using OAuth 2.0, the following configuration is required:
+To connect a Kafka client to Event Hubs using OAuth 2.0, the following configuration properties are required:
 
 ```properties
 bootstrap.servers=<namespace>.servicebus.windows.net:9093
@@ -120,29 +35,89 @@ sasl.mechanism=OAUTHBEARER
 oauth_cb=<Callback for retrieving OAuth Bearer token> 
 ```
 
-The return value of `oauth_cb` is expected to be a (token_str, expiry_time) tuple where expiry_time is the time in seconds since the epoch as a floating point number.
+The return value of `oauth_cb` must be a (`token_str`, `expiry_time`) tuple where `expiry_time` is the time in seconds since the epoch as a floating point number.
 See [Confluent Kafka for Python](https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html) for reference.
 
-An example `oauth_cb` and kafka client configuration is defined below:
+An example `oauth_cb` and kafka client configuration is shown below:
 
 ```python
 from azure.identity import DefaultAzureCredential
+from confluent_kafka import Producer
 from functools import partial
 
 def oauth_cb(cred, namespace_fqdn, config):
     # note: confluent_kafka passes 'sasl.oauthbearer.config' as the config param
-    access_token = cred.get_token('https://%s/.default' % namespace_fqdn)
+    access_token = cred.get_token(f'https://{namespace_fqdn}/.default')
     return access_token.token, access_token.expires_on
 
-az_credential = DefaultAzureCredential()
-eh_namespace_fqdn = '<namespace>.servicebus.windows.net'
-kafka_conf = {
-    'bootstrap.servers': '%s:9093' % namespace,
+# A credential object retrieves access tokens
+credential = DefaultAzureCredential()
+
+# The namespace FQDN is used both for specifying the server and as the token audience
+namespace_fqdn = '<namespace>.servicebus.windows.net'
+
+# Minimum required configuration to connect to Event Hubs for Kafka with AAD
+p = Producer({
+    'bootstrap.servers': f'{namespace_fqdn}:9093',
     'security.protocol': 'SASL_SSL',
     'sasl.mechanism': 'OAUTHBEARER',
-    'oauth_cb': partial(oauth_cb, az_credential, eh_namespace_fqdn),
-}
+    'oauth_cb': partial(oauth_cb, credential, namespace_fqdn),
+})
+```
 
-# Create Producer instance
-p = Producer(kafka_conf)
+## Prerequisites
+
+If you don't have an Azure subscription, create a [free account](https://azure.microsoft.com/free/?ref=microsoft.com&utm_source=microsoft.com&utm_medium=docs&utm_campaign=visualstudio) before you begin.
+
+You'll also need:
+
+* [Git](https://www.git-scm.com/downloads)
+* [Python](https://www.python.org/downloads/)
+* [Pip](https://pypi.org/project/pip/)
+
+## Create an Event Hubs namespace
+
+An Event Hubs namespace includes a Kafka endpoint and is required to send or receive data. See [Quickstart: Create an event hub using Azure portal](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-create) for instructions on creating an Event Hubs namespace.
+
+## Getting ready
+
+Now that you have an Event Hubs namespace, clone the repository and navigate to the `tutorials/oauth/python` directory:
+
+```bash
+git clone https://github.com/Azure/azure-event-hubs-for-kafka.git
+cd azure-event-hubs-for-kafka/tutorials/oauth/python
+```
+
+Install the sample dependencies:
+
+```shell
+python -m pip install -r requirements.txt
+```
+
+## Running the samples
+
+### Configuring credentials
+
+In this example, a service principal is used for the AAD credential. This service principal must have the `Azure Event Hubs Data Sender` and `Azure Event Hubs Data Receiver` roles (or equivalent) assigned on the target Event Hubs namespace. We configure `DefaultAzureCredential` by setting the following environment variables:
+
+```shell
+export AZURE_TENANT_ID=<TenantID>
+export AZURE_CLIENT_ID=<AppClientId>
+export AZURE_CLIENT_SECRET=<AppSecret>
+```
+
+### Producing
+
+```shell
+# Usage: producer.py <eventhubs-namespace> <topic>.
+python producer.py mynamespace.servicebus.windows.net topic1
+```
+
+> Note that the topic must already exist or else you will see an "Unknown topic or partition" error.
+
+### Consuming
+
+```shell
+# Usage: consumer.py [options..] <eventhubs-namespace> <group> <topic1> <topic2> ..
+python consumer.py mynamespace.servicebus.windows.net myconsumergroup topic1
 ```

--- a/tutorials/oauth/python/requirements.txt
+++ b/tutorials/oauth/python/requirements.txt
@@ -1,10 +1,2 @@
-#python -m pip install -r requirements.txt
-aiohttp
-azure.eventhub
-azure.identity
-python-dotenv
-confluent-kafka
 azure-identity
-azure.keyvault.certificates
-azure.keyvault.secrets
-az.cli
+confluent-kafka

--- a/tutorials/oauth/python/setup.sh
+++ b/tutorials/oauth/python/setup.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-sudo apt-get update
-
-sudo apt-get install python3.8
-
-echo "Setting up required dependencies"
-sudo pip3 --disable-pip-version-check --no-cache-dir install -r
-echo "Try running the samples now!"


### PR DESCRIPTION
Update README for changes made in https://github.com/noelbundick-msft/azure-event-hubs-for-kafka/pull/2

* Remove references to Python 2 (deprecated in 2020)
* Remove "Kafka-enabled Event Hubs" - all namespaces are enabled for Kafka these days
* Don't install build tools + librdkafka from scratch. It's included in the wheel for `confluent-kafka`
* Don't use a `setup.sh` that makes global changes to a user's dev machine
* Removes references to the `.env` file - it's not needed
* Add some info on `DefaultAzureCredential`
* Fix the tutorial directory path
* Remove reference to Event Hubs connection string